### PR TITLE
Fix colliding output paths

### DIFF
--- a/.github/workflows/sdk-publish-unstable.yaml
+++ b/.github/workflows/sdk-publish-unstable.yaml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Build packages
         run: |
-          dotnet build -c Release Jellyfin.Sdk -o artifacts
+          dotnet build -c Release Jellyfin.Sdk
 
       - name: Publish to nuget
         run: |
-          dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push artifacts/package/release/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Commit new changes to the repo
         run: |

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -50,11 +50,11 @@ jobs:
 
       - name: Build packages
         run: |
-          dotnet build -c Release Jellyfin.Sdk -o artifacts
+          dotnet build -c Release Jellyfin.Sdk
 
       - name: Publish to nuget
         run: |
-          dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push artifacts/package/release/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Commit new changes to the repo
         run: |

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #41

For documentation on `<UseArtifactsOutput>`, see: https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output

New artifacts layout:

![image](https://github.com/jellyfin/jellyfin-sdk-csharp/assets/6445614/ae81c0ee-d15c-4fef-8498-148aa576f5e5)

And the assemblies are now correct:

![image](https://github.com/jellyfin/jellyfin-sdk-csharp/assets/6445614/f18b0b1e-0130-4a00-8281-de9f6c181be7)

