### PR TITLE
Clean up build scripts and publish workflows

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "nuke"
       ]
+    },
+    "dotnet-setversion": {
+      "version": "4.0.0",
+      "commands": [
+        "setversion"
+      ]
     }
   }
 }

--- a/.github/workflows/sdk-publish-reusable.yaml
+++ b/.github/workflows/sdk-publish-reusable.yaml
@@ -1,0 +1,90 @@
+name: SDK Publish (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      configuration:
+        description: "Nuke configuration: stable or unstable"
+        type: string
+        required: true
+      version:
+        description: "Package version to set on Jellyfin.Sdk.csproj"
+        type: string
+        required: true
+      target-branch:
+        description: "Branch to commit and push regenerated sources to"
+        type: string
+        required: true
+      commit-message:
+        description: "Commit message for regenerated sources"
+        type: string
+        required: true
+      force-push:
+        description: "Force push the target branch (used for the rolling unstable branch)"
+        type: boolean
+        default: false
+    secrets:
+      NUGET_APIKEY:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    defaults:
+      run:
+        working-directory: ./src
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          cache: true
+          cache-dependency-path: src/**/packages.lock.json
+
+      - name: Restore packages
+        run: |
+          dotnet restore
+          dotnet tool restore
+
+      - name: Set project version
+        run: dotnet setversion ${{ inputs.version }} Jellyfin.Sdk/Jellyfin.Sdk.csproj
+
+      - name: Generate sdk
+        run: dotnet nuke --configuration ${{ inputs.configuration }}
+
+      - name: Build packages
+        run: dotnet build -c Release Jellyfin.Sdk/Jellyfin.Sdk.csproj
+
+      - name: Publish to nuget
+        run: dotnet nuget push artifacts/package/release/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Commit new changes to the repo
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+          COMMIT_MESSAGE: ${{ inputs.commit-message }}
+          FORCE_PUSH: ${{ inputs.force-push }}
+        run: |
+          git config user.name jellyfin-bot
+          git config user.email team@jellyfin.org
+          if [[ "$FORCE_PUSH" == "true" ]]; then
+            git checkout -B "$TARGET_BRANCH"
+          else
+            git pull --ff-only origin "$TARGET_BRANCH"
+          fi
+          git add Jellyfin.Sdk/Generated Jellyfin.Sdk/Jellyfin.Sdk.csproj
+          git commit --allow-empty -m "$COMMIT_MESSAGE"
+          if [[ "$FORCE_PUSH" == "true" ]]; then
+            git push --force origin "$TARGET_BRANCH"
+          else
+            git push origin "$TARGET_BRANCH"
+          fi

--- a/.github/workflows/sdk-publish-unstable.yaml
+++ b/.github/workflows/sdk-publish-unstable.yaml
@@ -9,61 +9,22 @@ on:
       - master
 
 jobs:
-  publish:
+  version:
     runs-on: ubuntu-24.04
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-    defaults:
-      run:
-        working-directory: ./src
+    outputs:
+      number: ${{ steps.version.outputs.number }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: "master"
-          fetch-depth: 0
+      - id: version
+        run: echo "number=$(date +'%Y.%m.%d')-unstable.$(date +'%Y%m%d%H%M')" >> "$GITHUB_OUTPUT"
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: |
-            8.0.x
-
-      - name: Install dotnet-setversion
-        run: |
-          dotnet tool install -g dotnet-setversion
-
-      - name: Restore packages
-        run: |
-          dotnet restore
-          dotnet tool restore
-
-      - name: Create new version string
-        id: version
-        run: |
-          echo "number=$(echo $(date +'%Y.%m.%d')-unstable.$(date +'%Y%m%d%H%M'))" >> $GITHUB_OUTPUT
-
-      - name: Set project version
-        run: |
-          setversion ${{ steps.version.outputs.number }} Jellyfin.Sdk/Jellyfin.Sdk.csproj
-
-      - name: Generate sdk
-        run: |
-          dotnet nuke --configuration unstable
-
-      - name: Build packages
-        run: |
-          dotnet build -c Release Jellyfin.Sdk
-
-      - name: Publish to nuget
-        run: |
-          dotnet nuget push artifacts/package/release/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
-      - name: Commit new changes to the repo
-        run: |
-          git config user.name jellyfin-bot
-          git config user.email team@jellyfin.org
-          git checkout -B openapi-unstable
-          git add .
-          git commit --allow-empty -m "Update unstable OpenAPI client"
-          git push --force origin openapi-unstable
+  publish:
+    needs: version
+    uses: ./.github/workflows/sdk-publish-reusable.yaml
+    with:
+      configuration: unstable
+      version: ${{ needs.version.outputs.number }}
+      target-branch: openapi-unstable
+      commit-message: Update unstable OpenAPI client
+      force-push: true
+    secrets:
+      NUGET_APIKEY: ${{ secrets.NUGET_APIKEY }}

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -6,61 +6,23 @@ on:
       - published
 
 jobs:
-  publish:
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-    defaults:
-      run:
-        working-directory: ./src
+  version:
     runs-on: ubuntu-24.04
     if: ${{ startsWith(github.ref, 'refs/tags/v') && github.repository == 'jellyfin/jellyfin-sdk-csharp' }}
+    outputs:
+      number: ${{ steps.version.outputs.number }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: "master"
+      - id: version
+        run: echo "number=$(echo '${{ github.event.release.tag_name }}' | tr -d v)" >> "$GITHUB_OUTPUT"
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: |
-            8.0.x
-
-      - name: Install dotnet-setversion
-        run: |
-          dotnet tool install -g dotnet-setversion
-
-      - name: Restore packages
-        run: |
-          dotnet restore
-          dotnet tool restore
-
-      - name: Get Version
-        id: version
-        run: |
-          echo "number=$( echo ${{ github.event.release.tag_name }} | tr -d v )" >> $GITHUB_OUTPUT
-
-      - name: Set project version
-        run: |
-          setversion ${{ steps.version.outputs.number }} Jellyfin.Sdk/Jellyfin.Sdk.csproj
-
-      - name: Generate sdk
-        run: |
-          dotnet nuke --configuration stable
-
-      - name: Build packages
-        run: |
-          dotnet build -c Release Jellyfin.Sdk
-
-      - name: Publish to nuget
-        run: |
-          dotnet nuget push artifacts/package/release/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
-      - name: Commit new changes to the repo
-        run: |
-          git config user.name jellyfin-bot
-          git config user.email team@jellyfin.org
-          git pull
-          git add .
-          git commit --allow-empty -m "Update stable OpenAPI client"
-          git push --force origin master
+  publish:
+    needs: version
+    uses: ./.github/workflows/sdk-publish-reusable.yaml
+    with:
+      configuration: stable
+      version: ${{ needs.version.outputs.number }}
+      target-branch: master
+      commit-message: Update stable OpenAPI client
+      force-push: false
+    secrets:
+      NUGET_APIKEY: ${{ secrets.NUGET_APIKEY }}

--- a/build.ps1
+++ b/build.ps1
@@ -14,9 +14,9 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 ###########################################################################
 
 $BuildProjectFile = "$PSScriptRoot\nuke\_nuke.csproj"
-$TempDirectory = "$PSScriptRoot\\.nuke\temp"
+$TempDirectory = "$PSScriptRoot\.nuke\temp"
 
-$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetGlobalFile = "$PSScriptRoot\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "STS"
 

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,9 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/nuke/_nuke.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
+TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
 
-DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR/global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="STS"
 

--- a/nuke/Generate.cs
+++ b/nuke/Generate.cs
@@ -74,22 +74,6 @@ public partial class Generate : NukeBuild
             DotNetTasks.DotNet(
                 arguments: "kiota update --output Generated",
                 workingDirectory: Solution.Jellyfin_Sdk.Directory);
-            
-            // TODO remove when Kiota 1.1.2 is released.
-            var outputPath = Path.Combine(Solution.Jellyfin_Sdk.Directory, "Generated");
-            foreach (var file in Directory.EnumerateFiles(outputPath, "*.cs", SearchOption.AllDirectories))
-            {
-                var contents = File.ReadAllText(file);
-                contents = contents
-                    .Replace(
-                        "application/json;profile=\"CamelCase\"",
-                        "application/json;profile=\\\"CamelCase\\\"")
-                    .Replace(
-                        "application/json;profile=\"PascalCase\"",
-                        "application/json;profile=\\\"PascalCase\\\"");
-
-                File.WriteAllText(file, contents);
-            }
         });
 
     [GeneratedRegex("""


### PR DESCRIPTION
## Summary

- Extract the duplicated stable/unstable publish logic into a reusable `sdk-publish-reusable.yaml`. The two callers now only compute their version string and forward `configuration` / `target-branch` / `force-push`.
- Install **both** 8.0.x and 10.0.x in CI. The Nuke build project (`nuke/_nuke.csproj`) targets `net10.0` and `Jellyfin.Sdk.csproj` multi-targets through `net10.0`, but the workflows were only installing 8.0.x — the build only worked because `ubuntu-24.04` happens to ship a compatible SDK.
- Enable NuGet caching in `setup-dotnet`.
- **Drop `git push --force origin master`** from the stable release path. Switched to a fast-forward `git pull --ff-only` + plain push. The unstable branch still force-pushes (it's the rolling regen branch — that's the intent, gated behind a `force-push` input).
- Scope `git add` to `Jellyfin.Sdk/Generated` + `Jellyfin.Sdk.csproj` instead of `git add .` so accidental files in the runner workspace can't sneak into a publish commit.
- Move `dotnet-setversion` from a global runtime `dotnet tool install` into `.config/dotnet-tools.json` so it's pinned and restored alongside `kiota` / `nuke`.
- Remove the stale Kiota workaround in `nuke/Generate.cs` (the "TODO remove when Kiota 1.1.2 is released" loop that re-escaped `"` in generated `.cs` files). Verified that Kiota 1.31.1 already emits properly escaped C# strings — the replacement was a no-op.
- Strip stray `//` and `\\` in `build.sh` / `build.ps1` path joins.

## Test plan

- [x] `dotnet build nuke/_nuke.csproj` succeeds locally with the workaround removed
- [x] `dotnet tool restore` resolves `kiota`, `nuke`, and `setversion`
- [x] All three workflow YAML files parse
- [ ] Next unstable run (cron or manual `workflow_dispatch`) succeeds end-to-end — this is the main thing to watch since it exercises the reusable workflow on the unstable path
- [ ] First stable release after merge succeeds end-to-end (no `--force` push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)